### PR TITLE
Sb enable 3d obstacle avoidance

### DIFF
--- a/realsense2_camera/src/base_realsense_node.cpp
+++ b/realsense2_camera/src/base_realsense_node.cpp
@@ -1675,6 +1675,7 @@ void BaseRealSenseNode::frame_callback(rs2::frame frame)
             t = ros::Time(_ros_time_base.toSec()+ (/*ms*/ frame_time - /*ms*/ _camera_time_base) / /*ms to seconds*/ 1000);
         }
 
+        // debug code to measure fps. left here to be used in all filter development
         /*static ros::Time prev_time = t;
         ROS_WARN_STREAM("Last frame time " << (t.toNSec() - prev_time.toNSec()) / 1000000UL << "ms");
         prev_time = t;*/
@@ -1722,7 +1723,7 @@ void BaseRealSenseNode::frame_callback(rs2::frame frame)
                     }
                     else{
                         count_skipped++;
-                        ROS_WARN_STREAM("Skip bright region depth removal (No infra1 frame received)." << " Skipped " << count_skipped << "/" << count_total << "frames.");
+                        ROS_DEBUG_STREAM("Skip bright region depth removal (No infra1 frame received)." << " Skipped " << count_skipped << "/" << count_total << "frames.");
                     }
                 }
 

--- a/realsense2_camera/src/base_realsense_node.cpp
+++ b/realsense2_camera/src/base_realsense_node.cpp
@@ -1713,8 +1713,13 @@ void BaseRealSenseNode::frame_callback(rs2::frame frame)
 
                 if (_enable_bright_region_removal)
                 {
-                    static int count_total = 0, count_skipped = 0; 
-                    count_total++;
+                    static unsigned long count_total = 0, count_skipped = 0;
+                    ++count_total;
+                    // reset counter at max range
+                    if (std::numeric_limits<unsigned long>::max() == count_total)
+                    {
+                        count_total = 0, count_skipped = 0;
+                    }
                     if (infrared1_frame)
                     {
                         // Bright region removal
@@ -1722,7 +1727,7 @@ void BaseRealSenseNode::frame_callback(rs2::frame frame)
                         bright_removed = remove_bright_regions(depth_frame, infrared1_frame);
                     }
                     else{
-                        count_skipped++;
+                        ++count_skipped;
                         ROS_DEBUG_STREAM("Skip bright region depth removal (No infra1 frame received)." << " Skipped " << count_skipped << "/" << count_total << "frames.");
                     }
                 }

--- a/realsense2_camera/src/base_realsense_node.cpp
+++ b/realsense2_camera/src/base_realsense_node.cpp
@@ -1718,6 +1718,7 @@ void BaseRealSenseNode::frame_callback(rs2::frame frame)
                     // reset counter at max range
                     if (std::numeric_limits<unsigned long>::max() == count_total)
                     {
+                        ROS_WARN_STREAM("Max frames reached. Counter reset.");
                         count_total = 0, count_skipped = 0;
                     }
                     if (infrared1_frame)

--- a/realsense2_camera/src/base_realsense_node.cpp
+++ b/realsense2_camera/src/base_realsense_node.cpp
@@ -1729,7 +1729,8 @@ void BaseRealSenseNode::frame_callback(rs2::frame frame)
                     }
                     else{
                         ++count_skipped;
-                        ROS_DEBUG_STREAM("Skip bright region depth removal (No infra1 frame received)." << " Skipped " << count_skipped << "/" << count_total << "frames.");
+                        double frame_loss = 100.0 * (double (count_skipped) / double (count_total));
+                        ROS_DEBUG("Skip bright region depth removal (No infra1 frame received). Skipped %5.2f%% frames.\n", frame_loss);
                     }
                 }
 


### PR DESCRIPTION
Basic PR to enable 3D obstacle avaoidance.

Enables a much more stable running RealSense with the Sootballs. Updated drivers, library SDK, realsense-ros package matched with correct firmware version etc.

resolves: https://www.wrike.com/open.htm?id=435656180

documentation: https://docs.google.com/document/d/1Dg6gszNfD36r9-z7hvgF-JKsA93_GhdvBopIPmeXlRo/edit#heading=h.slxbv6bl2nly
