### PR TITLE
Remove public nodehandle to nodelet

### DIFF
--- a/realsense2_camera/src/realsense_node_factory.cpp
+++ b/realsense2_camera/src/realsense_node_factory.cpp
@@ -91,7 +91,7 @@ void RealSenseNodeFactory::getDevice(rs2::device_list list)
 			ROS_INFO("Resetting device...");
 			_device.hardware_reset();
 			_device = rs2::device();
-			
+
 		}
 		catch(const std::exception& ex)
 		{
@@ -196,7 +196,7 @@ void RealSenseNodeFactory::onInit()
 
 void RealSenseNodeFactory::StartDevice()
 {
-	ros::NodeHandle nh = getNodeHandle();
+	ros::NodeHandle nh = getPrivateNodeHandle();
 	ros::NodeHandle privateNh = getPrivateNodeHandle();
 	// TODO
 	std::string pid_str(_device.get_info(RS2_CAMERA_INFO_PRODUCT_ID));


### PR DESCRIPTION
Makes the nodelets launch with only private nodehandle to preserve the nodelet namespace